### PR TITLE
Fix GitHub Actions for Merge build

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.15.0'
       - run: cd client && npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
Specify node v16.15.0 for merge builds as well in order to resolve npm ci dependency issues with --legacy-peer-deps detailed in PR https://github.com/mikezhen/petchat/pull/1.