### PR TITLE
Remove PR trigger on main branch

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - 'server/**'
   pull_request:
-    branches:
-      - main
     paths:
       - 'server/**'
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - 'client/**'
   pull_request:
-    branches:
-      - main
     paths:
       - 'client/**'
 

--- a/.github/workflows/function.yml
+++ b/.github/workflows/function.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - 'function/**'
   pull_request:
-    branches:
-      - main
     paths:
       - 'function/**'
 


### PR DESCRIPTION
Currently, the workflow is set to trigger whenever changes are updated from `main` branch into an open PR. We do not want to trigger all 3 workflows by simply updating a PR therefore we are only using `paths` filter for build.