### PR TITLE
fix: add --force to functions deploy to auto-configure cleanup policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: firebase deploy --only firestore,storage --project pawcode-85f05
 
       - name: Deploy Cloud Functions
-        run: firebase deploy --only functions --project pawcode-85f05
+        run: firebase deploy --only functions --force --project pawcode-85f05
 
       - name: Deploy to Firebase Hosting
         run: firebase deploy --only hosting --project pawcode-85f05


### PR DESCRIPTION
## Summary

Firebase Functions deploy was completing successfully but then erroring because no artifact cleanup policy was configured in `us-central1`. Adding `--force` to the deploy command instructs the Firebase CLI to automatically set up the cleanup policy.

## Change

`firebase deploy --only functions` → `firebase deploy --only functions --force`

## Test plan

- [x] CI passes
- [ ] After merge, confirm deploy completes without the cleanup policy error

🤖 Generated with [Claude Code](https://claude.com/claude-code)