### PR TITLE
ci: split CI and Deploy into separate chained workflows

### DIFF
--- a/.github/workflows/build-suite.yml
+++ b/.github/workflows/build-suite.yml
@@ -1,8 +1,8 @@
 name: Build Suite
 
-# Reusable workflow — called by ci.yml and deploy.yml.
-# Pass upload_artifacts: true only from deploy.yml so the compiled
-# output is available to the deploy job.
+# Reusable workflow — called by ci.yml.
+# Pass upload_artifacts: true on push to main so the compiled output is
+# available to the separate Deploy workflow (deploy.yml).
 
 on:
   workflow_call:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
-name: CI / Deploy
+name: CI
 
-# Runs on PRs targeting main (pre-merge gate) and on push to main (deploy).
-# On push to main the build artifact is uploaded and the deploy job runs.
-# On PRs the deploy job is skipped and no artifact is stored.
-# This ensures the exact artifact validated by CI is the one shipped to production.
+# Runs on PRs targeting main (pre-merge gate) and on push to main.
+# On push to main the compiled output is uploaded as an artifact, which the
+# separate Deploy workflow picks up after this run succeeds (see deploy.yml).
 #
 # Branch protection for `main` should require these status checks to pass:
 #   - "tests / Unit & component tests"
@@ -30,47 +29,6 @@ jobs:
     needs: tests
     uses: ./.github/workflows/build-suite.yml
     with:
+      # Only publish the artifact on push to main, so Deploy can consume it.
       upload_artifacts: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     secrets: inherit
-
-  # ── Runs only on push to main; skipped on branches and PRs ────────────────
-  deploy:
-    name: Deploy to Firebase
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install app dependencies
-        run: npm ci
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: build-output
-
-      - name: Install function dependencies
-        run: npm ci
-        working-directory: functions
-
-      - uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PAWCODE_85F05 }}
-
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools
-
-      - name: Deploy Firestore rules & indexes
-        run: firebase deploy --only firestore,storage --project pawcode-85f05
-
-      - name: Deploy Cloud Functions
-        run: firebase deploy --only functions --force --project pawcode-85f05
-
-      - name: Deploy to Firebase Hosting
-        run: firebase deploy --only hosting --project pawcode-85f05

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy
+
+# Runs only after the CI workflow completes successfully on `main`.
+# It does NOT re-run tests or rebuild — it downloads the exact artifact CI
+# produced and ships that, so production gets precisely what was validated.
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read # required to download the artifact from the triggering CI run
+
+jobs:
+
+  deploy:
+    name: Deploy to Firebase
+    runs-on: ubuntu-latest
+    # Only deploy when the triggering CI run was a push to main that passed.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    steps:
+      # Check out the exact commit CI validated (not just the latest main).
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Download build artifacts from the CI run
+        uses: actions/download-artifact@v7
+        with:
+          name: build-output
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install function dependencies
+        run: npm ci
+        working-directory: functions
+
+      - uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PAWCODE_85F05 }}
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy Firestore rules & indexes
+        run: firebase deploy --only firestore,storage --project pawcode-85f05
+
+      - name: Deploy Cloud Functions
+        run: firebase deploy --only functions --force --project pawcode-85f05
+
+      - name: Deploy to Firebase Hosting
+        run: firebase deploy --only hosting --project pawcode-85f05


### PR DESCRIPTION
## Summary

Separates the previously-merged `CI / Deploy` pipeline into two distinct workflows so deploys are decoupled from PR-gating CI, chained via `workflow_run`.

```
ci.yml ("CI")            deploy.yml ("Deploy")
├ on: PR -> main         ├ on: workflow_run [CI] completed, branches: [main]
├ on: push -> main       ├ if: conclusion == success && event == push
├ tests (reusable)       ├ checkout head_sha (matches the artifact)
└ build (reusable)       ├ download build-output from the CI run
   └ uploads artifact    ├ npm ci (functions) + firebase-tools
      on push to main    └ deploy firestore/storage -> functions -> hosting
```

## Key optimization

Deploy no longer re-runs tests or rebuilds. It downloads the **exact artifact** the CI run produced (`run-id` + `GITHUB_TOKEN`, `actions: read`) and ships that — production gets precisely what CI validated, with no duplicated work.

## Details

- **CI** (`ci.yml`): runs on PRs to main and push to main; runs tests + build; publishes the compiled output as an artifact only on push to main. The deploy job was removed.
- **Deploy** (`deploy.yml`): triggered via `workflow_run` after CI completes successfully on main (push events only). Checks out `github.event.workflow_run.head_sha` so the Firestore rules and functions source match the artifact.
- Keeps `npm ci` in `functions` (the Firebase CLI loads the compiled functions locally to enumerate them at deploy time); drops the redundant app `npm ci` since Hosting only uploads the static `out/` directory.
- Deploy has its own concurrency group with `cancel-in-progress: false` so a deploy is never interrupted mid-flight.

## Notes

- `workflow_run`-triggered workflows only fire once `deploy.yml` exists on the **default branch**, so the chain becomes active from the merge of this PR onward — the first post-merge push to main will deploy.
- Branch-protection required checks are unchanged (the four `tests / …` and `build / …` checks); Deploy runs after and is not a PR gate.

## Verification

- All four workflow YAML files parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)