### PR TITLE
ci: show triggering commit/PR in the Deploy run name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ name: Deploy
 # It does NOT re-run tests or rebuild — it downloads the exact artifact CI
 # produced and ships that, so production gets precisely what was validated.
 
+# Surface the triggering commit/PR in the run title (workflow_run runs would
+# otherwise show only a generic name). display_title mirrors what CI shows —
+# the squash-merge commit message, including the "(#NN)" PR reference.
+run-name: "Deploy: ${{ github.event.workflow_run.display_title }}"
+
 on:
   workflow_run:
     workflows: [CI]


### PR DESCRIPTION
## Summary

`workflow_run`-triggered runs default to a generic title (just "Deploy #N"), unlike CI runs which show the commit/PR title. This adds a top-level `run-name` to `deploy.yml` so the Deploy run displays the same context:

```yaml
run-name: "Deploy: ${{ github.event.workflow_run.display_title }}"
```

`github.event.workflow_run.display_title` mirrors what the CI run showed — the squash-merge commit message, including the `(#NN)` PR reference — so it's immediately clear which change a deploy shipped.

## Example

A deploy triggered by merging PR #103 would show as:

> **Deploy: ci: split CI and Deploy into separate chained workflows (#103)**

## Verification

- `deploy.yml` parses cleanly.
- Takes effect on the next deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)