### PR TITLE
fix: clean URLs (no trailing slash) + bolder back arrows

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -17,6 +17,7 @@
     "public": "out",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "cleanUrls": true,
+    "trailingSlash": false,
     "headers": [
       {
         "source": "/_next/static/**",

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: 'export',
-  trailingSlash: true,
+  trailingSlash: false,
   compress: true,
   poweredByHeader: false,
   images: {

--- a/src/app/dashboard/edit/page.tsx
+++ b/src/app/dashboard/edit/page.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/lib/auth-context'
 import { getPet, updatePet } from '@/lib/pets'
 import { getUser } from '@/lib/users'
 import PetForm from '@/components/PetForm'
+import BackArrow from '@/components/BackArrow'
 import UnsavedChangesModal from '@/components/UnsavedChangesModal'
 import { useUnsavedChanges } from '@/lib/useUnsavedChanges'
 import type { Pet, UserProfile } from '@/types'
@@ -52,9 +53,9 @@ function EditPageInner() {
           type="button"
           onClick={leave.requestLeave}
           aria-label="Back to dashboard"
-          className="text-gray-600 hover:text-gray-900"
+          className="-ml-1 text-gray-700 hover:text-gray-900"
         >
-          ←
+          <BackArrow />
         </button>
         <h1 className="text-lg font-semibold text-gray-900">Edit {pet.name}</h1>
       </header>

--- a/src/app/dashboard/pets/new/page.tsx
+++ b/src/app/dashboard/pets/new/page.tsx
@@ -10,6 +10,7 @@ import { createPet, getPetsByOwner } from '@/lib/pets'
 import { getUser } from '@/lib/users'
 import { ACTIVE_PET_LIMIT, TOTAL_PET_LIMIT } from '@/lib/petLimits'
 import PetForm from '@/components/PetForm'
+import BackArrow from '@/components/BackArrow'
 import UnsavedChangesModal from '@/components/UnsavedChangesModal'
 import { useUnsavedChanges } from '@/lib/useUnsavedChanges'
 import type { Pet, UserProfile } from '@/types'
@@ -57,9 +58,9 @@ export default function NewPetPage() {
           type="button"
           onClick={leave.requestLeave}
           aria-label="Back to dashboard"
-          className="text-gray-600 hover:text-gray-900"
+          className="-ml-1 text-gray-700 hover:text-gray-900"
         >
-          ←
+          <BackArrow />
         </button>
         <h1 className="text-lg font-semibold text-gray-900">Add New Pet</h1>
       </header>

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -14,6 +14,7 @@ import { resizeImage } from '@/lib/resizeImage'
 import { cropImage } from '@/lib/cropImage'
 import type { CropArea } from '@/lib/cropImage'
 import ImageCropModal from '@/components/ImageCropModal'
+import BackArrow from '@/components/BackArrow'
 import UnsavedChangesModal from '@/components/UnsavedChangesModal'
 import SaveButton, { type SaveStatus } from '@/components/SaveButton'
 import { useUnsavedChanges } from '@/lib/useUnsavedChanges'
@@ -133,9 +134,9 @@ export default function ProfilePage() {
           type="button"
           onClick={leave.requestLeave}
           aria-label="Back to dashboard"
-          className="text-gray-600 hover:text-gray-900"
+          className="-ml-1 text-gray-700 hover:text-gray-900"
         >
-          ←
+          <BackArrow />
         </button>
         <h1 className="text-lg font-semibold text-gray-900">My Profile</h1>
       </header>

--- a/src/app/dashboard/qr/page.tsx
+++ b/src/app/dashboard/qr/page.tsx
@@ -9,6 +9,7 @@ import { doc, getDoc } from 'firebase/firestore'
 import { getFirebaseDb } from '@/lib/firebase'
 import QRCode from 'qrcode'
 import Link from 'next/link'
+import BackArrow from '@/components/BackArrow'
 
 function QRPageInner() {
   const params = useSearchParams()
@@ -39,7 +40,7 @@ function QRPageInner() {
   return (
     <div className="min-h-screen bg-gray-100">
       <header className="bg-white border-b border-gray-200 px-4 py-4 flex items-center gap-3">
-        <Link href="/dashboard" className="text-gray-400 hover:text-gray-600">←</Link>
+        <Link href="/dashboard" aria-label="Back to dashboard" className="-ml-1 text-gray-700 hover:text-gray-900"><BackArrow /></Link>
         <div>
           <h1 className="text-lg font-semibold text-gray-900">
             {petName ? `${petName}'s QR Code` : 'QR Code'}

--- a/src/components/BackArrow.tsx
+++ b/src/components/BackArrow.tsx
@@ -1,0 +1,17 @@
+/** Bold back chevron used in page headers. Inherits color via currentColor. */
+export default function BackArrow({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={`w-6 h-6 ${className}`}
+    >
+      <path d="M15 18l-6-6 6-6" />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary

Two related UI/UX fixes, plus a merge of the latest `main`.

### 1. Drop trailing slashes from URLs
Links rendered with a trailing slash before the query string (e.g. `/dashboard/qr/?id=x`), which looked off. The links in code were already correct; the cause was **`trailingSlash: true`** in `next.config.ts`, which makes Next.js append a slash to every internal navigation.

- **`next.config.ts`**: `trailingSlash: true` -> `false`. Links now render clean (`/dashboard/qr?id=x`), and the static export switches from directory-style (`dashboard/qr/index.html`) to file-style (`dashboard/qr.html`), which the existing `cleanUrls: true` serves at the slash-free path.
- **`firebase.json`**: added `"trailingSlash": false` so Firebase Hosting 301-redirects any lingering trailing-slash URLs (old bookmarks / already-printed QR links) to the clean form, **preserving the query string**.

### 2. Bolder, more apparent back arrows
The thin `←` glyph can't really render bold, so it's replaced with a crisp SVG chevron.

- New `BackArrow` component (SVG chevron, strokeWidth 2.75) used across the profile, new pet, edit pet, and QR page headers.
- Darkened the color to `gray-700` / hover `gray-900`. The QR page back link was the faintest (`gray-400`) and is now consistent with the rest.

## Notes

- Already-printed QR tags point at `/pet?id=x` (no trailing slash in code), so they're unaffected; the hosting redirect covers anything that did pick up a slash.
- Branch merged up to date with `main` (which now includes the security hardening from #105) — auto-merged cleanly; the back-arrow and security changes touch different lines of the same files.

## Verification

- Production build emits the expected file-style routes (`dashboard/qr.html`, `pet.html`, …)
- `tsc --noEmit` clean
- Lint: 0 errors
- 87 app tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)