### PR TITLE
feat(privacy): keep finder & app pages out of search indexes

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -44,6 +44,18 @@
           { "key": "X-Content-Type-Options", "value": "nosniff" },
           { "key": "X-Frame-Options", "value": "DENY" }
         ]
+      },
+      {
+        "source": "/pet",
+        "headers": [
+          { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
+        ]
+      },
+      {
+        "source": "/auth/**",
+        "headers": [
+          { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
+        ]
       }
     ],
     "rewrites": [

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+# The finder page (/pet) shows an owner's contact details, and /dashboard
+# and /auth are the private app. Keep all of them out of search indexes.
+User-agent: *
+Disallow: /pet
+Disallow: /dashboard
+Disallow: /auth


### PR DESCRIPTION
## Summary

Step 1 of the finder-page privacy work. The public finder page (`/pet`) displays an owner's name and phone number, so it must never be crawled or appear in search results.

## Changes

- **`public/robots.txt`**: disallow `/pet`, `/dashboard`, and `/auth` for all crawlers.
- **`firebase.json`**: serve `X-Robots-Tag: noindex, nofollow` on `/pet` and `/auth/**` as the authoritative "do not index" signal. (Both pages are client components, so Next's `metadata` API isn't available to them — the HTTP header is the robust path.)

## Scope / what this does and doesn't do

- ✅ **Closes the search-engine exposure vector** — finder pages with contact info won't be indexed or surface in Google.
- ⏳ **Does NOT stop direct scraping** of the publicly-readable `pets/{petId}` document. A broker reads the raw doc via the Firestore REST API, not the page. Closing that requires moving contact info behind a gated reveal (App Check + lost-status + rate limit) — tracked as **Step 2**.

## Verification

- `firebase.json` is valid JSON
- Production build succeeds; `robots.txt` is emitted to `out/`
- 87 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)